### PR TITLE
new Hash#chain_change_keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bidu-core_ext (1.2.3)
+    bidu-core_ext (1.2.4)
       activesupport (~> 5.1.1)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,31 +2,31 @@ PATH
   remote: .
   specs:
     bidu-core_ext (1.2.3)
-      activesupport
+      activesupport (~> 5.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.0.1)
+    activesupport (5.1.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    coderay (1.1.0)
-    concurrent-ruby (1.0.2)
+    coderay (1.1.1)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    i18n (0.7.0)
+    i18n (0.8.4)
+    json (2.1.0)
     method_source (0.8.2)
-    minitest (5.9.1)
-    multi_json (1.10.1)
-    pry (0.10.3)
+    minitest (5.10.2)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    rake (10.3.2)
+    rake (12.0.0)
     rspec (2.99.0)
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
@@ -34,15 +34,15 @@ GEM
     rspec-core (2.99.2)
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.2)
-    simplecov (0.9.1)
+    rspec-mocks (2.99.4)
+    simplecov (0.14.1)
       docile (~> 1.1.0)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.8.0)
-    simplecov-html (0.8.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.1)
     slop (3.6.0)
-    thread_safe (0.3.5)
-    tzinfo (1.2.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -51,11 +51,12 @@ PLATFORMS
 DEPENDENCIES
   bidu-core_ext!
   bundler (~> 1.6)
-  pry-nav
-  rake
+  pry (~> 0.10.4)
+  pry-nav (~> 0.2.4)
+  rake (~> 12.0.0)
   rspec (~> 2.14)
-  rspec-mocks
-  simplecov
+  rspec-mocks (~> 2.99.4)
+  simplecov (~> 0.14.1)
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ returns
   { 'CA_B' => 1 }
 ```
 
+###chain_change_keys
+Change the hash keys usin a chained method call
+
+```ruby
+  { ca_b: 1 }.chain_change_keys(:to_s, :upcase, :to_sym)
+```
+returns
+```ruby
+  { CA_B: 1 }
+```
+
 ### change_values
 Change the values of the array
 ```ruby

--- a/core_ext.gemspec
+++ b/core_ext.gemspec
@@ -15,12 +15,13 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport'
+  spec.add_runtime_dependency 'activesupport', '~> 5.1.1'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 12.0.0'
   spec.add_development_dependency 'rspec', '~> 2.14'
-  spec.add_development_dependency 'rspec-mocks'
-  spec.add_development_dependency 'pry-nav'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'rspec-mocks', '~> 2.99.4'
+  spec.add_development_dependency 'pry', '~> 0.10.4'
+  spec.add_development_dependency 'pry-nav', '~> 0.2.4'
+  spec.add_development_dependency 'simplecov', '~> 0.14.1'
 end

--- a/lib/bidu/core_ext/version.rb
+++ b/lib/bidu/core_ext/version.rb
@@ -1,5 +1,5 @@
 module Bidu
   module CoreExt
-    VERSION = '1.2.3'
+    VERSION = '1.2.4'
   end
 end

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -90,7 +90,7 @@ class Hash
 
   # change all keys returning the new map
   # options: { recursive: true }
-  # ex: { "a":1 }.change_keys{ |key| key.upcase } == { "A":1 }
+  # ex: { "a" =>1 }.change_keys{ |key| key.upcase } == { "A" => 1 }
   def change_keys(options = {}, &block)
     deep_dup.change_keys!(options, &block)
   end

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -102,6 +102,24 @@ class Hash
     Hash::KeyChanger.new(self).change_keys(options, &block)
   end
 
+  # change all publicaly sending method calls
+  # options: { recursive: true }
+  # ex: { a: 1 }.chain_change_keys(:to_s, :upcase) == { "A" =>1 }
+  def chain_change_keys(*calls)
+    deep_dup.chain_change_keys!(*calls)
+  end
+
+  # change all publicaly sending method calls
+  # options: { recursive: true }
+  # ex: { a: 1 }.chain_change_keys(:to_s, :upcase) == { "A" =>1 }
+  def chain_change_keys!(*calls)
+    options = calls.extract_options!
+
+    calls.inject(self) do |h, c|
+      h.change_keys! { |k| k.public_send(c) }
+    end
+  end
+
   # prepend a string to all keys
   # options {
   #  recursive: true,

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -116,7 +116,7 @@ class Hash
     options = calls.extract_options!
 
     calls.inject(self) do |h, c|
-      h.change_keys! { |k| k.public_send(c) }
+      h.change_keys!(options) { |k| k.public_send(c) }
     end
   end
 

--- a/lib/hash.rb
+++ b/lib/hash.rb
@@ -115,8 +115,8 @@ class Hash
   def chain_change_keys!(*calls)
     options = calls.extract_options!
 
-    calls.inject(self) do |h, c|
-      h.change_keys!(options) { |k| k.public_send(c) }
+    calls.inject(self) do |h, m|
+      h.change_keys!(options, &m)
     end
   end
 

--- a/spec/lib/hash/deep_hash_constructor_spec.rb
+++ b/spec/lib/hash/deep_hash_constructor_spec.rb
@@ -96,7 +96,7 @@ describe Hash::DeepHashConstructor do
           'quote_request.personal.person[1].name' => 'Some name 2',
           'quote_request.personal.person[1].age' => 23,
           'request[0].status.clazz' => String,
-          'request[1].status.clazz' => Fixnum,
+          'request[1].status.clazz' => Integer,
           'request[2].status.clazz' => Date,
           'trials' => 3
         }
@@ -114,7 +114,7 @@ describe Hash::DeepHashConstructor do
           },
           'request' => [
             { 'status' => { 'clazz' => String } },
-            { 'status' => { 'clazz' => Fixnum } },
+            { 'status' => { 'clazz' => Integer } },
             { 'status' => { 'clazz' => Date } }
           ],
           'trials' => 3

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -173,7 +173,7 @@ describe Hash do
           'quote_request.personal.person[1].name' => 'Some name 2',
           'quote_request.personal.person[1].age' => 23,
           'request[0].status.clazz' => String,
-          'request[1].status.clazz' => Fixnum,
+          'request[1].status.clazz' => Integer,
           'request[2].status.clazz' => Date,
           'trials' => 3
         }
@@ -191,7 +191,7 @@ describe Hash do
           },
           'request' => [
             { 'status' => { 'clazz' => String } },
-            { 'status' => { 'clazz' => Fixnum } },
+            { 'status' => { 'clazz' => Integer } },
             { 'status' => { 'clazz' => Date } }
           ],
           'trials' => 3

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Hash do
   it_behaves_like 'a class with change_key method'
+  it_behaves_like 'a class with chain_change_key method'
   it_behaves_like 'a class with camlize_keys method'
   it_behaves_like 'a class with underscore_keys method'
   it_behaves_like 'a class with append_keys method'

--- a/spec/lib/hash_spec.rb
+++ b/spec/lib/hash_spec.rb
@@ -5,7 +5,7 @@ describe Hash do
   it_behaves_like 'a class with camlize_keys method'
   it_behaves_like 'a class with underscore_keys method'
   it_behaves_like 'a class with append_keys method'
-  it_behaves_like 'a class with change_kvalues method'
+  it_behaves_like 'a class with change_values method'
   it_behaves_like 'a class with remap method'
   it_behaves_like 'an object with chain_fetch method'
 

--- a/spec/support/shared_examples/chain_hash_keys_changer.rb
+++ b/spec/support/shared_examples/chain_hash_keys_changer.rb
@@ -65,7 +65,7 @@ shared_examples 'a method that is able to chain change keys' do |method|
       context 'without recursion' do
         let(:recursive) { false }
         let(:expected) { { 'a' => 1, 'b' =>  { c: 3, 'd' => 4 } } }
-        #it_behaves_like 'result is as expected'
+        it_behaves_like 'result is as expected'
       end
     end
   end
@@ -73,8 +73,16 @@ shared_examples 'a method that is able to chain change keys' do |method|
   context 'with many many levels' do
     let(:hash) { { a: 1, b: { c: 2, d: { e: 3, f: 4 } } } }
     let(:expected) do
-      { 'a': 1, 'b': { 'c': 2, 'd': { 'e': 3, 'f': 4 } } }
+      { 'a' => 1, 'b' => { 'c' => 2, 'd' => { 'e' => 3, 'f' => 4 } } }
     end
-    #it_behaves_like 'result is as expected'
+    it_behaves_like 'result is as expected'
+  end
+
+  context 'calling with chained transformations' do
+    let(:transformations) { [ :to_s, :upcase, :to_sym ] }
+
+    let(:hexpected) do
+      { A: 1, B: 2, C: { D: 3, E: 4 }, F: [{ G: 5 }, { H: 6 }] }
+    end
   end
 end

--- a/spec/support/shared_examples/chain_hash_keys_changer.rb
+++ b/spec/support/shared_examples/chain_hash_keys_changer.rb
@@ -1,0 +1,80 @@
+shared_examples 'a class with chain_change_key method' do
+  let(:hash) do
+    { 'a' => 1, b: 2, c: { d: 3, e: 4 }, f: [{ g: 5 }, { h: 6 }] }
+  end
+
+  describe :chain_change_keys do
+
+    it_behaves_like 'a method that is able to chain change keys', :chain_change_keys
+    it 'does not affects the original hash' do
+      expect do
+        hash.chain_change_keys(:to_s, :upcase)
+      end.not_to change { hash }
+    end
+  end
+
+  describe :ichain_change_keys! do
+    it_behaves_like 'a method that is able to chain change keys', :chain_change_keys!
+
+    it 'affects the original hash' do
+      expect do
+        hash.chain_change_keys!(:to_s, :upcase)
+      end.to change { hash }
+    end
+  end
+end
+
+shared_examples 'a method that is able to chain change keys' do |method|
+  let(:result) { hash.public_send(method, *transformations, options) }
+  let(:options) { {} }
+  let(:transformations) { [ :to_s ] }
+
+  context 'with simple level hash' do
+    let(:hash) { { 'a' => 1, b: 2 } }
+
+    context 'with symbol transformation' do
+      let(:transformations) { [ :to_sym ] }
+      let(:expected) { { a: 1, b: 2 } }
+      it_behaves_like 'result is as expected'
+    end
+
+    context 'with string transformation' do
+      let(:expected) { { 'a' => 1, 'b' => 2 } }
+      it_behaves_like 'result is as expected'
+    end
+  end
+
+  context 'with recursive hash' do
+    let(:hash) { { 'a' => 1, b:  { c: 3, 'd' => 4 } } }
+    let(:expected) do
+      { 'a' => 1, 'b' =>  { 'c' => 3, 'd' => 4 } }
+    end
+
+    context 'when no options are given' do
+      it_behaves_like 'result is as expected'
+    end
+
+    context 'when options are given' do
+      let(:options) { { recursive: recursive } }
+
+      context 'with recursion' do
+        let(:recursive) { true }
+        it_behaves_like 'result is as expected'
+      end
+
+      context 'without recursion' do
+        let(:recursive) { false }
+        let(:expected) { { 'a' => 1, 'b' =>  { c: 3, 'd' => 4 } } }
+        #it_behaves_like 'result is as expected'
+      end
+    end
+  end
+
+  context 'with many many levels' do
+    let(:hash) { { a: 1, b: { c: 2, d: { e: 3, f: 4 } } } }
+    let(:expected) do
+      { 'a': 1, 'b': { 'c': 2, 'd': { 'e': 3, 'f': 4 } } }
+    end
+    #it_behaves_like 'result is as expected'
+  end
+end

--- a/spec/support/shared_examples/expected.rb
+++ b/spec/support/shared_examples/expected.rb
@@ -1,0 +1,6 @@
+shared_examples 'result is as expected' do
+  it 'is as expected' do
+    expect(result).to eq(expected)
+  end
+end
+

--- a/spec/support/shared_examples/hash_keys_changer.rb
+++ b/spec/support/shared_examples/hash_keys_changer.rb
@@ -4,7 +4,6 @@ shared_examples 'a class with change_key method' do
   end
 
   describe :change_keys do
-
     it_behaves_like 'a method that is able to change keys', :change_keys
     it 'does not affects the original hash' do
       expect do
@@ -21,12 +20,6 @@ shared_examples 'a class with change_key method' do
         hash.change_keys!(recursive: true) { |k| "foo_#{k}" }
       end.to change { hash }
     end
-  end
-end
-
-shared_examples 'result is as expected' do
-  it 'is as expected' do
-    expect(result).to eq(expected)
   end
 end
 

--- a/spec/support/shared_examples/value_changer.rb
+++ b/spec/support/shared_examples/value_changer.rb
@@ -1,4 +1,4 @@
-shared_examples 'a class with change_kvalues method' do
+shared_examples 'a class with change_values method' do
   let(:subject) { { a: 1, b: 2, c: { d: 3, e: 4 } } }
 
   describe :change_values do


### PR DESCRIPTION
###chain_change_keys
Change the hash keys usin a chained method call

```ruby
  { ca_b: 1 }.chain_change_keys(:to_s, :upcase, :to_sym)
```
returns
```ruby
  { CA_B: 1 }
```
